### PR TITLE
Update orcid-model for Maven Central release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target/
 .classpath
-
-
+.idea

--- a/README.md
+++ b/README.md
@@ -1,3 +1,54 @@
+# Fork of ORCID-Model to support Jakarta EE
+
+This fork of https://github.com/dockstore/orcid-model/ is an EXACT COPY of that codebase,
+with very minor modifications for DSpace:
+* Modified `pom.xml` to us to release it to Maven Central under `org.dspace:orcid-model-jakarta` (as no Jakarta EE compatible version exists in Maven Central).
+* Modified `pom.xml` to use latest versions of dependencies to align with Spring v6.
+* Fixed a few tests which failed compilation in Spring v6
+* Added Build/Test & Release instructions below.
+
+This fork is only necessary until `org.orcid:orcid-model` becomes compatible with Jakarta EE.
+See https://github.com/ORCID/orcid-model/issues/50
+
+## Use Maven Dependency
+NOTE: This fork is released under the `org.dspace` group for usage by DSpace.
+The official ORCID API is released under `org.orcid:orcid-model`.
+```
+   <dependency>
+      <groupId>org.dspace</groupId>
+      <artifactId>orcid-model-jakarta</artifactId>
+      <version>3.3.0</version>
+   </dependency>
+```
+
+## Build & Test
+```
+mvn install
+```
+
+## SNAPSHOT release to Maven Central Snapshots
+Releases a `*-SNAPSHOT` release to https://oss.sonatype.org/content/repositories/snapshots
+```
+mvn clean javadoc:jar source:jar deploy
+```
+
+## Official Release to Maven Central
+```
+# Test release process
+mvn release:prepare -DdryRun=true -Drelease
+
+# Tag release in GitHub
+mvn release:prepare -Dresume=false -Drelease
+
+# Deploy release to Sonatype
+mvn release:perform -Drelease
+
+# Login to http://oss.sonatype.org/
+# Verify and release to Maven Central
+```
+
+----------------------------------
+
 # ORCID-Model
 
 This repository contains the data model used in the ORCID Registry and APIs as well as Java classes used for mashalling/unmarshalling.

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.orcid</groupId>
+	<groupId>org.dspace</groupId>
 	<artifactId>orcid-model-jakarta</artifactId>
-	<version>3.3.1-SNAPSHOT</version>
+	<version>3.3.0-SNAPSHOT</version>
 
-	<name>ORCID - Model</name>
-	<description>Container for all classes that will be used to marshal and unmarshal XML/JSON from the API</description>
-	<url>https://github.com/ORCID/orcid-model</url>
+	<name>ORCID - Model (Jakarta version)</name>
+	<description>Forked version of ORCID Model API to support Jakarta EE</description>
+	<url>https://github.com/DSpace/orcid-model</url>
 
 	<properties>
-		<github.url>scm:git:git@github.com:denis-yuen/orcid-model.git</github.url>
+		<github.url>scm:git:git@github.com:DSpace/orcid-model.git</github.url>
 		<main.basedir>${project.basedir}</main.basedir>
-		<swagger.version>2.2.7</swagger.version>
-		<jena.version>3.6.0</jena.version>
-		<jackson.version>2.14.1</jackson.version>
-		<spring.version>5.2.8.RELEASE</spring.version>
+		<java.version>17</java.version>
+		<swagger.version>2.2.21</swagger.version>
+		<jena.version>4.9.0</jena.version>
+		<jackson.version>2.16.2</jackson.version>
+		<spring.version>6.1.5</spring.version>
 	</properties>
 
 	<licenses>
@@ -37,38 +38,51 @@
 		<connection>${github.url}</connection>
 		<developerConnection>${github.url}</developerConnection>
 		<url>${github.url}</url>
-	  <tag>3.3.0</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<profiles>
 		<profile>
-			<id>maven-central</id>
+			<id>release</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<!-- Enable this profile if we are doing a release (-Drelease) -->
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<inherited>true</inherited>
+						<version>3.13.0</version>
 						<configuration>
-							<source>11</source>
-							<target>11</target>
+							<release>${java.version}</release>
 						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.7</version>
+						<version>1.6.13</version>
 						<extensions>true</extensions>
 						<configuration>
+							<!-- In your settings.xml, your username/password
+                                 MUST be specified for server 'ossrh' -->
 							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<!-- Disable autoclose of repository after upload, as this sometimes times out -->
+							<skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+							<!-- Require manual verification / release to Maven Central -->
+							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<!-- Increase Staging timeout to 10mins -->
+							<stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
 						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>2.2.1</version>
+						<version>3.3.0</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -81,7 +95,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.5.0</version>
+						<version>3.6.3</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -94,7 +108,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>3.2.1</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -102,12 +116,6 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
-								<configuration>
-               		 						<gpgArguments>
-                    								<arg>--pinentry-mode</arg>
-                    								<arg>loopback</arg>
-                							</gpgArguments>
-            							</configuration>
 							</execution>
 						</executions>
 					</plugin>
@@ -120,42 +128,52 @@
 	<build>
 		<plugins>
 			<plugin>
-	        <groupId>org.apache.maven.plugins</groupId>
-	        <artifactId>maven-enforcer-plugin</artifactId>
-	        <version>3.0.0</version>
-	        <executions>
-	            <execution>
-	            <id>enforce-versions</id>
-	            <goals>
-	                <goal>enforce</goal>
-	            </goals>
-	            <configuration>
-	                <rules>
-	                    <requireMavenVersion>
-	                        <version>3.8.6</version>
-	                    </requireMavenVersion>
-	                    <requireJavaVersion>
-	                        <version>17</version>
-	                    </requireJavaVersion>
-	                </rules>
-	            </configuration>
-	            </execution>
-	        </executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.4.1</version>
+				<executions>
+					<execution>
+						<id>enforce-java</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>${java.version}</version>
+								</requireJavaVersion>
+								<requireMavenVersion>
+									<version>[3.8,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+					<!-- Make sure that we do not have conflicting dependencies-->
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<DependencyConvergence />
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 	        </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
-				<inherited>true</inherited>
+				<version>3.13.0</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<release>${java.version}</release>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.3</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -165,14 +183,33 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Specify our settings for new releases via 'mvn release:*' -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<!-- During release:prepare and release:perform, pass the "release" property to enable the
+                     "release" profile (and enable/disable other profiles based on whether they need releasing) -->
+					<arguments>-Drelease</arguments>
+					<goals>deploy</goals>
+					<!-- Suggest tagging the release in SCM as "orcid-model-jakarta-[version]" -->
+					<tagNameFormat>orcid-model-jakarta-@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
+	<!-- Configure our release repositories to use Sonatype.
+         See: http://central.sonatype.org/pages/apache-maven.html -->
 	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
 		<repository>
-			<id>central</id>
-			<name>artifacts.oicr.on.ca-releases</name>
-			<url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
 
@@ -180,7 +217,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.2</version>
+			<version>3.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>
@@ -263,7 +300,7 @@
 	    <dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>31.1-jre</version>
+			<version>33.0.0-jre</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/test/java/org/orcid/record/ValidateV2IdentifiersTest.java
+++ b/src/test/java/org/orcid/record/ValidateV2IdentifiersTest.java
@@ -59,7 +59,7 @@ public class ValidateV2IdentifiersTest {
         assertEquals("funding:organization-defined-type",funding.getOrganizationDefinedType().getContent());
         assertNotNull(funding.getExternalIdentifiers());
         assertNotNull(funding.getExternalIdentifiers().getExternalIdentifier());
-        Assert.notEmpty(funding.getExternalIdentifiers().getExternalIdentifier());
+        Assert.notEmpty(funding.getExternalIdentifiers().getExternalIdentifier(), "not empty");
         assertEquals("grant_number",funding.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
         assertEquals("funding:external-identifier-value",funding.getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
         assertEquals(new Url("http://tempuri.org"),funding.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl());

--- a/src/test/java/org/orcid/record/ValidateV2_1IdentifiersTest.java
+++ b/src/test/java/org/orcid/record/ValidateV2_1IdentifiersTest.java
@@ -59,7 +59,7 @@ public class ValidateV2_1IdentifiersTest {
         assertEquals("funding:organization-defined-type",funding.getOrganizationDefinedType().getContent());
         assertNotNull(funding.getExternalIdentifiers());
         assertNotNull(funding.getExternalIdentifiers().getExternalIdentifier());
-        Assert.notEmpty(funding.getExternalIdentifiers().getExternalIdentifier());
+        Assert.notEmpty(funding.getExternalIdentifiers().getExternalIdentifier(), "not empty");
         assertEquals("grant_number",funding.getExternalIdentifiers().getExternalIdentifier().get(0).getType());
         assertEquals("funding:external-identifier-value",funding.getExternalIdentifiers().getExternalIdentifier().get(0).getValue());
         assertEquals(new Url("http://tempuri.org"),funding.getExternalIdentifiers().getExternalIdentifier().get(0).getUrl());


### PR DESCRIPTION
Update POM and README for release to Maven Central.

Also ensure all dependencies are up to date.

Minor fixes to a few tests which have compilation failures with Spring v6

This PR was released to Maven Central snapshot repository as `3.3.0-SNAPSHOT`