### PR TITLE
Update POM to use Sonatype's Central Portal for Maven Releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,24 +65,25 @@
 							<release>${java.version}</release>
 						</configuration>
 					</plugin>
+					<!--
+						Configure Central Publishing Plugin for new releases via Sonatype.
+						See: https://central.sonatype.org/publish/publish-portal-maven/
+						A few notes on how this plugin works:
+						1. In your settings.xml, your user/password tokens MUST be specified for a <server> tag
+						   with <id>central</id>. Otherwise, you will see a 401 Unauthorized error.
+						2. The <distributionManagement> POM section is no longer needed. This plugin defaults to
+						   uploading releases to Central Portal (https://central.sonatype.com/publishing)
+						   and -SNAPSHOT releases to https://central.sonatype.com/repository/maven-snapshots/
+						3. Sonatype has publishing *requirements* which must be met. Our POM is already configured to
+						   meet those requirements: https://central.sonatype.org/publish/requirements/
+					-->
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>0.8.0</version>
 						<extensions>true</extensions>
-						<configuration>
-							<!-- In your settings.xml, your username/password
-                                 MUST be specified for server 'ossrh' -->
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<!-- Disable autoclose of repository after upload, as this sometimes times out -->
-							<skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-							<!-- Require manual verification / release to Maven Central -->
-							<autoReleaseAfterClose>false</autoReleaseAfterClose>
-							<!-- Increase Staging timeout to 10mins -->
-							<stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
-						</configuration>
 					</plugin>
+					<!-- Per Sonatype publishing requirements, generate Source JAR files -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
@@ -96,6 +97,7 @@
 							</execution>
 						</executions>
 					</plugin>
+					<!-- Per Sonatype publishing requirements, generate JavaDocs -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
@@ -109,6 +111,8 @@
 							</execution>
 						</executions>
 					</plugin>
+					<!-- Per Sonatype publishing requirements, sign any new releases via GPG.
+					     NOTE: you may optionally specify the "gpg.passphrase" in your settings.xml -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
@@ -203,19 +207,6 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<!-- Configure our release repositories to use Sonatype.
-         See: http://central.sonatype.org/pages/apache-maven.html -->
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
# References
This PR is a port of https://github.com/DSpace/DSpace/pull/10986 , specific to `DSpace/orcid-model`.

# Description
As of June 30, 2025, Sonatype has retired their older OSSRH system used to release Maven modules to Maven Central. The replacement is their new "Central Portal"

https://central.sonatype.org/pages/ossrh-eol/

This PR updates our Parent POM to use the new Central Portal for releases, following their documented guidelines: https://central.sonatype.org/publish/publish-portal-guide/

**See https://github.com/DSpace/DSpace/pull/10986 for more details.**


**WARNING: This is untested, but the only way to fully test it is to "cut" a new release.** I have tested this code in several `-SNAPSHOT` releases of `DSpace/DSpace` though and it has worked well.  Release procedure has also been updated: https://wiki.lyrasis.org/display/DSPACE/Release+Procedure